### PR TITLE
chore: add GH Action to check link validity periodically

### DIFF
--- a/.github/workflows/periodic-link-watcher.yml
+++ b/.github/workflows/periodic-link-watcher.yml
@@ -1,0 +1,46 @@
+name: Periodic Link Checker
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.9.3
+        with:
+          args: --verbose --no-progress --exclude-loopback .
+          output: ./lychee/out.md
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Find existing issue
+        id: find_issue
+        uses: micalevisk/last-issue-action@v2
+        if: failure()
+        with:
+          state: open
+          labels: |
+            broken link
+            automated issue
+      - name: Create or update issue for broken links
+        id: create_issue
+        uses: peter-evans/create-issue-from-file@v5
+        if: failure()
+        with:
+          title: Link Checker Report
+          # If issue number is empty a new issue gets created
+          issue-number: ${{ steps.find_issue.outputs.issue-number }}
+          content-filepath: ./lychee/out.md
+          labels: broken link, automated issue


### PR DESCRIPTION
This PR contains a new GH Action workflows that executes a periodic check of the links in the documents.

If an error occurs, a new issue is created containing the report of the link check run

@fabianleh : Please add the following tags to the issues to easily identify the issues that originate from broken links:

- broken link
- automated issue