### PR TITLE
fix: issue config mismatch for link checker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,5 @@
-blank_issues_enabled: false
+# Blank issues are needded for the link checker action
+blank_issues_enabled: true
 contact_links:
   - name: SAP BTP Solution Diagram Guidelines - Community Support
     url: https://github.com/SAP/btp-solution-diagrams/discussions


### PR DESCRIPTION
Fix error in GH Action for link checks - issues could not be created due to disabling blank issues