### PR TITLE
add Tip for drawio.png files

### DIFF
--- a/assets/all-in-one-starter-kits/README.md
+++ b/assets/all-in-one-starter-kits/README.md
@@ -6,3 +6,5 @@ In detail you will find here:
 - [Draw.io libraries](/assets/shape-libraries-and-editable-presets/draw.io/)
 - [Draw.io reusable examples](/assets/editable-diagram-examples/)
 - [BTP Solution Diagram design guidline](https://sap.github.io/btp-solution-diagrams/docs/solution_diagr_intro/big_picture/)
+
+> **Tip:** Not all tools can display draw.io files, but there's no need to keep two versions of a solution diagram—one as a draw.io file and another as a PNG file. Just export the diagram as a PNG (or SVG) image, including a copy, to enable continued editing via draw.io. For additional details, check the FAQ section of draw.io: [Export a diagram to a PNG image](https://www.drawio.com/doc/faq/export-to-png).


### PR DESCRIPTION
Add a Tip that you can have drawio diagram details in a png file. 